### PR TITLE
Scribble Composer UI

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,7 +1,7 @@
 class HomesController < ApplicationController
   def index
     if user_signed_in?
-      redirect_to scribbles_path
+      redirect_to new_scribble_path
     end
   end
 

--- a/app/javascript/controllers/composer_controller.js
+++ b/app/javascript/controllers/composer_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets =  ["count"];
+
+  connect() {
+    this.updateCount();
+  }
+
+  updateCount() {
+    const count = this.countTarget;
+    const textarea = this.element.querySelector("textarea");
+    const maxLength = textarea.getAttribute("maxlength");
+    const currentLength = textarea.value.length;
+    console.log("UPDATE COUNT")
+    count.textContent = `${currentLength}/${maxLength} characters`;
+  }
+}

--- a/app/models/scribble.rb
+++ b/app/models/scribble.rb
@@ -1,5 +1,5 @@
 class Scribble < ApplicationRecord
-  validates :content, presence: true, length: { maximum: 500 }
+  validates :content, presence: true, length: { maximum: 10000 }
 
   belongs_to :user
 end

--- a/app/models/scribble.rb
+++ b/app/models/scribble.rb
@@ -1,5 +1,5 @@
 class Scribble < ApplicationRecord
-  validates :content, presence: true, length: { maximum: 10000 }
+  validates :content, presence: true, length: { maximum: 1000 }
 
   belongs_to :user
 end

--- a/app/views/homes/_nav.html.erb
+++ b/app/views/homes/_nav.html.erb
@@ -6,7 +6,7 @@
         <span class="text-gray-300">Scribble.place</span>
       </a>
       <div class="flex items-center">
-        <%= link_to "Scribble", new_scribble_path, class: "text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium" %>
+        <%= link_to "Scribbles", scribbles_path, class: "text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium" %>
         <%= link_to "Account", edit_user_registration_path, class: "text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium" %>
       </div>
     </div>

--- a/app/views/scribbles/new.html.erb
+++ b/app/views/scribbles/new.html.erb
@@ -1,7 +1,16 @@
 <%= form_for(@scribble, as: :scribble) do |f| %>
-  <div class="mb-4">
-    <%= f.text_area :content, rows: 8, class: "text-lg resize-none w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring focus:ring-emerald-600" %>
-  </div>
+  <div class="mb-1" data-controller="composer">
+    <%= f.text_area :content, 
+                    rows: 15, 
+                    class: "text-lg resize-none w-full h-4/5 screen-80 px-3 py-2 border-none focus:outline-none focus:ring-0 focus:border-transparent overflow-auto", 
+                    maxlength: 1000, 
+                    autofocus: true,
+                    data: { target: "composer.count", action: "input->composer#updateCount" }
+    %>
 
-  <%= f.submit "Scribble!", class: "bg-cyan-700 text-white font-bold py-2 px-4 rounded hover:scale-105 transition ease-in-out duration-200" %>
+    <div class="mt-2">
+      <p data-composer-target="count"></p>
+      <%= f.submit "Scribble!", class: "bg-cyan-700 text-white font-bold py-2 px-4 rounded hover:scale-105 transition ease-in-out duration-200" %>
+    </div>
+  </div>
 <% end %>

--- a/db/migrate/20231026015758_increase_scribble_content_char_limit.rb
+++ b/db/migrate/20231026015758_increase_scribble_content_char_limit.rb
@@ -1,0 +1,5 @@
+class IncreaseScribbleContentCharLimit < ActiveRecord::Migration[7.0]
+  def change
+    change_column :scribbles, :content, :text, limit: 10000
+  end
+end

--- a/db/migrate/20231026015758_increase_scribble_content_char_limit.rb
+++ b/db/migrate/20231026015758_increase_scribble_content_char_limit.rb
@@ -1,5 +1,5 @@
 class IncreaseScribbleContentCharLimit < ActiveRecord::Migration[7.0]
   def change
-    change_column :scribbles, :content, :text, limit: 10000
+    change_column :scribbles, :content, :text, limit: 1000
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_23_124230) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_26_015758) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "scribbles", force: :cascade do |t|
-    t.string "content", limit: 500, null: false
+    t.text "content", null: false
     t.string "media_url"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false

--- a/spec/features/authing_users_spec.rb
+++ b/spec/features/authing_users_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Authenticating", type: :feature do
 
     click_button "Sign up"
 
-    expect(current_path).to eq(root_path)
+    expect(current_path).to eq(new_scribble_path)
   end
 
   scenario "User logs into Scribble" do
@@ -23,7 +23,7 @@ RSpec.feature "Authenticating", type: :feature do
 
     click_button "Log in"
 
-    expect(current_path).to eq(root_path)
+    expect(current_path).to eq(new_scribble_path)
     expect(page).to have_content("Signed in successfully.")
   end
 end

--- a/spec/models/scribble_spec.rb
+++ b/spec/models/scribble_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Scribble, type: :model do
     expect(scribble).to_not be_valid
   end
 
-  it "must not have content longer than 10000 characters" do
-    scribble = build(:scribble, content: "a" * 10001)
+  it "must not have content longer than 1000 characters" do
+    scribble = build(:scribble, content: "a" * 1001)
     expect(scribble).to_not be_valid
   end
 
-  it "can have content that is 10000 characters long" do
-    scribble = build(:scribble, content: "a" * 10000)
+  it "can have content that is 1000 characters long" do
+    scribble = build(:scribble, content: "a" * 1000)
     expect(scribble).to be_valid
   end
 end

--- a/spec/models/scribble_spec.rb
+++ b/spec/models/scribble_spec.rb
@@ -9,4 +9,14 @@ RSpec.describe Scribble, type: :model do
     scribble = build(:scribble, content: nil)
     expect(scribble).to_not be_valid
   end
+
+  it "must not have content longer than 10000 characters" do
+    scribble = build(:scribble, content: "a" * 10001)
+    expect(scribble).to_not be_valid
+  end
+
+  it "can have content that is 10000 characters long" do
+    scribble = build(:scribble, content: "a" * 10000)
+    expect(scribble).to be_valid
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
This PR includes several changes for composing and creating new Scribbles.

- [x] The default landing page for a logged in user is the Scribble Composer, not the list of written scribbles
- [x] Scribble content character count increases to 1000
- [x] The composer doesn't allow scribbles over the character count
- [x] Slight UI tweaks to the composer