### PR TITLE
Fix: Ensure that the user of the scribble is authed to edit

### DIFF
--- a/app/controllers/scribbles_controller.rb
+++ b/app/controllers/scribbles_controller.rb
@@ -23,6 +23,10 @@ class ScribblesController < ApplicationController
 
   def edit
     @scribble = Scribble.find(params[:id])
+
+    unless current_user == @scribble.user
+      redirect_to scribbles_path, alert: "You are not authorized to edit this scribble."
+    end
   end
 
   def update

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,4 +64,5 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::IntegrationHelpers, type: :feature
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/scribbles_controller_spec.rb
+++ b/spec/requests/scribbles_controller_spec.rb
@@ -1,0 +1,146 @@
+require "rails_helper"
+
+RSpec.describe ScribblesController, type: :request do
+  describe "GET #index" do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in user
+      get scribbles_path
+    end
+
+    it "responds with success" do
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #new" do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in user
+    end
+
+    before { get new_scribble_path }
+
+    it "responds with success" do
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "POST #create" do
+    let(:user) { create(:user) }
+    let(:scribble) { create(:scribble, user: user) }
+
+    before do
+      sign_in user
+      get scribbles_path
+    end
+
+    context "with valid attributes" do
+      let(:valid_attributes) { {scribble: { content: "Super duperness"}} }
+
+      it "creates a new scribble" do
+        expect {
+          post scribbles_path, params: valid_attributes
+        }.to change(Scribble, :count).by(1)
+      end
+
+      it "redirects to the scribbles index" do
+        post scribbles_path, params: valid_attributes
+        expect(response).to redirect_to(scribbles_path)
+      end
+    end
+
+    context "with invalid attributes" do
+      let(:invalid_attributes) { {scribble: {content: ""}} }
+
+      it "does not create a new scribble" do
+        expect {
+          post scribbles_path, params: invalid_attributes
+        }.not_to change(Scribble, :count)
+      end
+
+      it "returns an unprocessable entity status" do
+        post scribbles_path, params: invalid_attributes
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "GET #edit" do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user, email: "otheruser@scribble.place") }
+    let(:scribble) { create(:scribble, user: user) }
+
+    before do
+      sign_in user
+    end
+
+    context "when user is the owner" do
+      it "renders the edit template" do
+        get edit_scribble_path(scribble)
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when user is not the owner" do
+      before { sign_in other_user }
+
+      it "redirects to the scribbles path" do
+        get edit_scribble_path(scribble)
+        expect(response).to redirect_to(scribbles_path)
+      end
+    end
+  end
+
+  describe "PATCH #update" do
+    let(:user) { create(:user) }
+    let(:scribble) { create(:scribble, user: user, content: "Scribble content") }
+
+    before do
+      sign_in user
+    end
+
+    context "with valid attributes" do
+      it "updates the scribble" do
+        patch scribble_path(scribble), params: {scribble: {content: "Updated scribble content"}}
+        scribble.reload
+        expect(scribble.content).to eq "Updated scribble content"
+      end
+    end
+
+    context "with invalid attributes" do
+      it "re-renders the edit template" do
+        patch scribble_path(scribble), params: {scribble: {isengard: "Saruman ruins it for everyone"}}
+        expect(scribble.content).to eq "Scribble content"
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user, email: "otheremail@scribble.place") }
+    let(:scribble) { create(:scribble, user: user) }
+
+    context "when user is the owner of the scribble" do
+      before { sign_in user }
+
+      it "deletes the scribble" do
+        expect {
+          delete scribble_path(scribble)
+        }.to change(Scribble, :count).by(-1)
+      end
+    end
+
+    context "when user is not the owner of the scribble" do
+      before { sign_in other_user }
+
+      it "does not delete the scribble" do
+        expect {
+          delete scribble_path(scribble)
+        }.not_to change(Scribble, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces some much-needed request specs, and ensures that the edit action can only be reached by user that own a Scribble.